### PR TITLE
auto allocate directory in local and external cluster

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,9 +112,9 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>com.coveo</groupId>
+				<groupId>com.spotify.fmt</groupId>
 				<artifactId>fmt-maven-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.20</version>
 				<executions>
 					<execution>
 						<goals>

--- a/src/main/java/org/icgc/argo/workflow_management_scheduler/components/DirScheduler.java
+++ b/src/main/java/org/icgc/argo/workflow_management_scheduler/components/DirScheduler.java
@@ -28,7 +28,6 @@ public class DirScheduler {
   private final DirSchedulerConfig config;
   private final Map<String, Integer> workflowNameToCosts;
 
-
   public DirScheduler(DirSchedulerConfig config) {
     this.config = config;
     this.workflowNameToCosts =
@@ -57,7 +56,7 @@ public class DirScheduler {
         runsBySchedulingType.getOrDefault(RUN_WAITING_FOR_DIR, new ArrayList<>());
     val runReadyForInit = runsBySchedulingType.getOrDefault(RUN_READY_FOR_INIT, new ArrayList<>());
     val activeRuns = runsBySchedulingType.getOrDefault(ACTIVE_RUN, new ArrayList<>());
-    log.debug("runsWaitingForDir: {}",runsWaitingForDir);
+    log.debug("runsWaitingForDir: {}", runsWaitingForDir);
     if (!runsWaitingForDir.isEmpty()) {
       val scheduledRuns = getNextScheduledRuns(activeRuns, runsWaitingForDir);
       runReadyForInit.addAll(scheduledRuns);
@@ -110,7 +109,9 @@ public class DirScheduler {
 
               allocatedWorkDirValues.forEach(
                   value -> {
-                    checkDirectoryClusterPattern(value, "Please provide both directory and cluster values, Ex: directory:cluster");
+                    checkDirectoryClusterPattern(
+                        value,
+                        "Please provide both directory and cluster values, Ex: directory:cluster");
 
                     val nextRunToInit = queuedRunsForWf.remove(queuedRunsForWf.size() - 1);
                     // update template params
@@ -173,12 +174,16 @@ public class DirScheduler {
   }
 
   private String matchRunToKnownDirValues(Run run) {
-    return config.getDirValues().stream().filter(d -> run.isAnyDirParamMatched(getDirectory(d))).findFirst().orElse("");
+    return config.getDirValues().stream()
+        .filter(d -> run.isAnyDirParamMatched(getDirectory(d)))
+        .findFirst()
+        .orElse("");
   }
 
   private String replaceTemplateWithValue(
       String input, String templateRegex, String templateValue) {
-    log.debug("input, templateRegex, templateValue {} - {} - {}",input, templateRegex, templateValue);
+    log.debug(
+        "input, templateRegex, templateValue {} - {} - {}", input, templateRegex, templateValue);
     if (input != null && input.contains(templateRegex)) {
       return input.replaceAll(templateRegex, templateValue);
     }
@@ -188,7 +193,7 @@ public class DirScheduler {
   private String addClusterParam(String input, String templateValue) {
     if (input != null) {
       StringBuilder builder = new StringBuilder(input);
-      builder.setCharAt(input.lastIndexOf("}"),',');
+      builder.setCharAt(input.lastIndexOf("}"), ',');
       builder.append("\"cluster\"").append(":\"").append(templateValue).append("\"}");
       return new String(builder);
     }

--- a/src/main/java/org/icgc/argo/workflow_management_scheduler/components/DirScheduler.java
+++ b/src/main/java/org/icgc/argo/workflow_management_scheduler/components/DirScheduler.java
@@ -111,7 +111,7 @@ public class DirScheduler {
                   value -> {
                     checkDirectoryClusterPattern(
                         value,
-                        "Please provide both directory and cluster values, Ex: directory:cluster");
+                        "dirValues missing directory or cluster information. Ex: directory:cluster");
 
                     val nextRunToInit = queuedRunsForWf.remove(queuedRunsForWf.size() - 1);
                     // update template params

--- a/src/main/java/org/icgc/argo/workflow_management_scheduler/components/DirScheduler.java
+++ b/src/main/java/org/icgc/argo/workflow_management_scheduler/components/DirScheduler.java
@@ -110,28 +110,31 @@ public class DirScheduler {
                   value -> {
                     val nextRunToInit = queuedRunsForWf.remove(queuedRunsForWf.size() - 1);
                     // update template params
-                    val templatedJson =
+                    val preTemplatedJson =
                         replaceTemplateWithValue(
                             nextRunToInit.getWorkflowParamsJsonStr(),
                             config.getWorkDirTemplate(),
-                            value);
+                            value.split(":")[0]);
+
+                    val templatedJson = addClusterParam(preTemplatedJson, value.split(":")[1]);
+
                     nextRunToInit.setWorkflowParamsJsonStr(templatedJson);
                     // set dirs
                     val newWorkDir =
                         replaceTemplateWithValue(
                             nextRunToInit.getWorkflowEngineParams().getWorkDir(),
                             config.getWorkDirTemplate(),
-                            value);
+                            value.split(":")[0]);
                     val newProjectDir =
                         replaceTemplateWithValue(
                             nextRunToInit.getWorkflowEngineParams().getProjectDir(),
                             config.getWorkDirTemplate(),
-                            value);
+                            value.split(":")[0]);
                     val newLaunchDir =
                         replaceTemplateWithValue(
                             nextRunToInit.getWorkflowEngineParams().getLaunchDir(),
                             config.getWorkDirTemplate(),
-                            value);
+                            value.split(":")[0]);
                     nextRunToInit.getWorkflowEngineParams().setWorkDir(newWorkDir);
                     nextRunToInit.getWorkflowEngineParams().setProjectDir(newProjectDir);
                     nextRunToInit.getWorkflowEngineParams().setLaunchDir(newLaunchDir);
@@ -174,6 +177,16 @@ public class DirScheduler {
     log.debug("input, templateRegex, templateValue {} - {} - {}",input, templateRegex, templateValue);
     if (input != null && input.contains(templateRegex)) {
       return input.replaceAll(templateRegex, templateValue);
+    }
+    return input;
+  }
+
+  private String addClusterParam(String input, String templateValue) {
+    if (input != null) {
+      StringBuilder builder = new StringBuilder(input);
+      builder.setCharAt(input.lastIndexOf("}"),',');
+      builder.append("\"cluster\"").append(":\"").append(templateValue).append("\"}");
+      return new String(builder);
     }
     return input;
   }

--- a/src/main/java/org/icgc/argo/workflow_management_scheduler/components/DirScheduler.java
+++ b/src/main/java/org/icgc/argo/workflow_management_scheduler/components/DirScheduler.java
@@ -5,6 +5,7 @@ import static java.util.Collections.nCopies;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toMap;
+import static org.icgc.argo.workflow_management_scheduler.utils.DirectoryUtils.*;
 
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
@@ -12,8 +13,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -28,7 +27,7 @@ import org.springframework.stereotype.Component;
 public class DirScheduler {
   private final DirSchedulerConfig config;
   private final Map<String, Integer> workflowNameToCosts;
-  private final String DIRECTORY_CLUSTER_DELIMITER = ":";
+
 
   public DirScheduler(DirSchedulerConfig config) {
     this.config = config;
@@ -194,21 +193,6 @@ public class DirScheduler {
       return new String(builder);
     }
     return input;
-  }
-
-  private String getDirectory(String dirValue){
-    return dirValue.split(DIRECTORY_CLUSTER_DELIMITER)[0];
-  }
-
-  private String getCluster(String dirValue){
-    return dirValue.split(DIRECTORY_CLUSTER_DELIMITER)[1];
-  }
-
-  public static void checkDirectoryClusterPattern(String strToCheck, String message){
-    Matcher matcher = Pattern.compile(".*:.*").matcher(strToCheck);
-    if(!matcher.matches()){
-      throw new RuntimeException(message);
-    }
   }
 
   private Stream<String> getStreamOfNextSchedulableDirs(

--- a/src/main/java/org/icgc/argo/workflow_management_scheduler/components/GatekeeperClient.java
+++ b/src/main/java/org/icgc/argo/workflow_management_scheduler/components/GatekeeperClient.java
@@ -5,8 +5,6 @@ import static org.icgc.argo.workflow_management_scheduler.model.GqlResult.EMPTY_
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.icgc.argo.workflow_management_scheduler.model.GqlResult;
@@ -15,7 +13,6 @@ import org.icgc.argo.workflow_management_scheduler.model.SimpleQuery;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
-import org.springframework.util.ObjectUtils;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;

--- a/src/main/java/org/icgc/argo/workflow_management_scheduler/model/Run.java
+++ b/src/main/java/org/icgc/argo/workflow_management_scheduler/model/Run.java
@@ -30,11 +30,11 @@ public class Run {
 
   public Boolean isAnyDirParamMatched(@NonNull String startsWithStr) {
     return (workflowEngineParams.getWorkDir() != null
-            && workflowEngineParams.getWorkDir().startsWith(startsWithStr.split(":")[0]))
+            && workflowEngineParams.getWorkDir().startsWith(startsWithStr))
         || (workflowEngineParams.getLaunchDir() != null
-            && workflowEngineParams.getLaunchDir().startsWith(startsWithStr.split(":")[0]))
+            && workflowEngineParams.getLaunchDir().startsWith(startsWithStr))
         || (workflowEngineParams.getProjectDir() != null
-            && workflowEngineParams.getProjectDir().startsWith(startsWithStr.split(":")[0]));
+            && workflowEngineParams.getProjectDir().startsWith(startsWithStr));
   }
 
   public Optional<String> getRepository() {

--- a/src/main/java/org/icgc/argo/workflow_management_scheduler/model/Run.java
+++ b/src/main/java/org/icgc/argo/workflow_management_scheduler/model/Run.java
@@ -30,11 +30,11 @@ public class Run {
 
   public Boolean isAnyDirParamMatched(@NonNull String startsWithStr) {
     return (workflowEngineParams.getWorkDir() != null
-            && workflowEngineParams.getWorkDir().startsWith(startsWithStr))
+            && workflowEngineParams.getWorkDir().startsWith(startsWithStr.split(":")[0]))
         || (workflowEngineParams.getLaunchDir() != null
-            && workflowEngineParams.getLaunchDir().startsWith(startsWithStr))
+            && workflowEngineParams.getLaunchDir().startsWith(startsWithStr.split(":")[0]))
         || (workflowEngineParams.getProjectDir() != null
-            && workflowEngineParams.getProjectDir().startsWith(startsWithStr));
+            && workflowEngineParams.getProjectDir().startsWith(startsWithStr.split(":")[0]));
   }
 
   public Optional<String> getRepository() {

--- a/src/main/java/org/icgc/argo/workflow_management_scheduler/rabbitmq/SchedulerStreams.java
+++ b/src/main/java/org/icgc/argo/workflow_management_scheduler/rabbitmq/SchedulerStreams.java
@@ -49,6 +49,7 @@ public class SchedulerStreams {
 
   @Value("${scheduler.consumer.bufferDurationSec}")
   private Long bufferDurationSec;
+
   private final RabbitEndpointService rabbit;
   private final GatekeeperClient gatekeeperClient;
   private final DirScheduler dirScheduler;
@@ -124,7 +125,6 @@ public class SchedulerStreams {
                     .then(Mono.just(tx)))
         .subscribe(Transaction::commit);
   }
-
 
   private Flux<WfMgmtRunMsg> fetchAllGatekeeperRunsAndCreateNextInitRunsMsgs() {
     return gatekeeperClient

--- a/src/main/java/org/icgc/argo/workflow_management_scheduler/utils/DirectoryUtils.java
+++ b/src/main/java/org/icgc/argo/workflow_management_scheduler/utils/DirectoryUtils.java
@@ -1,9 +1,8 @@
 package org.icgc.argo.workflow_management_scheduler.utils;
 
-import lombok.experimental.UtilityClass;
-
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class DirectoryUtils {
@@ -11,19 +10,18 @@ public class DirectoryUtils {
   private final String DIRECTORY_CLUSTER_DELIMITER = ":";
   private final String DIRECTORY_CLUSTER_PATTERN = ".*:.*";
 
-  public String getDirectory(String dirValue){
+  public String getDirectory(String dirValue) {
     return dirValue.split(DIRECTORY_CLUSTER_DELIMITER)[0];
   }
 
-  public String getCluster(String dirValue){
+  public String getCluster(String dirValue) {
     return dirValue.split(DIRECTORY_CLUSTER_DELIMITER)[1];
   }
 
-  public static void checkDirectoryClusterPattern(String strToCheck, String message){
+  public static void checkDirectoryClusterPattern(String strToCheck, String message) {
     Matcher matcher = Pattern.compile(DIRECTORY_CLUSTER_PATTERN).matcher(strToCheck);
-    if(!matcher.matches()){
+    if (!matcher.matches()) {
       throw new RuntimeException(message);
     }
   }
-
 }

--- a/src/main/java/org/icgc/argo/workflow_management_scheduler/utils/DirectoryUtils.java
+++ b/src/main/java/org/icgc/argo/workflow_management_scheduler/utils/DirectoryUtils.java
@@ -20,7 +20,7 @@ public class DirectoryUtils {
 
   public static void checkDirectoryClusterPattern(String strToCheck, String message) {
     Matcher matcher = Pattern.compile(DIRECTORY_CLUSTER_PATTERN).matcher(strToCheck);
-    if (!matcher.matches()) {
+    if (!matcher.matches() || strToCheck.contains(" ") || strToCheck.split(DIRECTORY_CLUSTER_DELIMITER).length < 2) {
       throw new RuntimeException(message);
     }
   }

--- a/src/main/java/org/icgc/argo/workflow_management_scheduler/utils/DirectoryUtils.java
+++ b/src/main/java/org/icgc/argo/workflow_management_scheduler/utils/DirectoryUtils.java
@@ -1,0 +1,29 @@
+package org.icgc.argo.workflow_management_scheduler.utils;
+
+import lombok.experimental.UtilityClass;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@UtilityClass
+public class DirectoryUtils {
+
+  private final String DIRECTORY_CLUSTER_DELIMITER = ":";
+  private final String DIRECTORY_CLUSTER_PATTERN = ".*:.*";
+
+  public String getDirectory(String dirValue){
+    return dirValue.split(DIRECTORY_CLUSTER_DELIMITER)[0];
+  }
+
+  public String getCluster(String dirValue){
+    return dirValue.split(DIRECTORY_CLUSTER_DELIMITER)[1];
+  }
+
+  public static void checkDirectoryClusterPattern(String strToCheck, String message){
+    Matcher matcher = Pattern.compile(DIRECTORY_CLUSTER_PATTERN).matcher(strToCheck);
+    if(!matcher.matches()){
+      throw new RuntimeException(message);
+    }
+  }
+
+}

--- a/src/main/java/org/icgc/argo/workflow_management_scheduler/utils/RabbitmqUtils.java
+++ b/src/main/java/org/icgc/argo/workflow_management_scheduler/utils/RabbitmqUtils.java
@@ -64,7 +64,6 @@ public class RabbitmqUtils {
         .createTransactionalConsumerStream(queueName, WfMgmtRunMsg.class);
   }
 
-
   Function<WfMgmtRunMsg, String> routingKeySelector() {
     return msg -> msg.getState().toString();
   }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -27,8 +27,10 @@ scheduler:
   workDirTemplate: "<SCHEDULED_DIR>"
   maxCostPerDir: 3
   dirValues:
-    - "nfs-local/nfs-1"
-    - "nfs-local/nfs-2"
+    - "nfs-local/nfs-1:default"
+    - "nfs-local/nfs-2:default"
+    - "nfs-external/nfs-1:cluster2"
+    - "nfs-external/nfs-1:cluster2"
   workflows:
     - repository: "argo/hello"
       name: "hello"

--- a/src/test/java/org/icgc/argo/workflow_management_scheduler/DirSchedulerTests.java
+++ b/src/test/java/org/icgc/argo/workflow_management_scheduler/DirSchedulerTests.java
@@ -2,6 +2,7 @@ package org.icgc.argo.workflow_management_scheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
@@ -12,6 +13,7 @@ import org.icgc.argo.workflow_management_scheduler.model.Run;
 import org.icgc.argo.workflow_management_scheduler.model.WorkflowProps;
 import org.icgc.argo.workflow_management_scheduler.rabbitmq.schema.RunState;
 import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.StringUtils;
 
 public class DirSchedulerTests {
   private static final String ALIGN_NAME = "ALIGN";
@@ -23,8 +25,10 @@ public class DirSchedulerTests {
   private static final String HELLO_WF_URL = "http://www.github.com/org/HELLO";
 
   private static final String WORK_DIR_TEMPLATE = "<SCHEDULED_DIR>";
-  private static final String WORK_DIR_0 = "/nfs/dir-0";
-  private static final String WORK_DIR_1 = "/nfs/dir-1";
+  private static final String WORK_DIR_0 = "/nfs/dir-0:cluster-0";
+  private static final String WORK_DIR_1 = "/nfs/dir-1:cluster-1";
+
+  private static final String NO_CLUSTER_DIR = "/nfs/dir-1";
   private static final Integer MAX_COST_PER_DIR = 2;
 
   private static final DirSchedulerConfig config =
@@ -34,19 +38,56 @@ public class DirSchedulerTests {
           ImmutableList.of(WORK_DIR_0, WORK_DIR_1),
           ImmutableList.of(
               new WorkflowProps(ALIGN_NAME, ALIGN_WF_REPO, 2, 2),
-              new WorkflowProps(WGS_NAME, WGS_SANGER_WF_REPO, 4, 1)));
+              new WorkflowProps(WGS_NAME, WGS_SANGER_WF_REPO, 5, 1)));
 
   private final DirScheduler dirScheduler = new DirScheduler(config);
+
+  @Test
+  public void testMissingClusterCheck() {
+
+    final DirSchedulerConfig config =
+        new DirSchedulerConfig(
+            "<SCHEDULED_DIR>",
+            MAX_COST_PER_DIR,
+            ImmutableList.of(NO_CLUSTER_DIR),
+            ImmutableList.of(new WorkflowProps(WGS_NAME, WGS_SANGER_WF_REPO, 1, 1)));
+
+    final DirScheduler dirScheduler = new DirScheduler(config);
+
+    val runs =
+        ImmutableList.of(
+            createRun("run-1", RunState.QUEUED, WGS_SANGER_WF_URL, WORK_DIR_TEMPLATE, null));
+
+    assertThrows(
+        RuntimeException.class,
+        () -> {
+          val initializedRuns = dirScheduler.getNextInitializedRuns(ImmutableList.copyOf(runs));
+        });
+  }
 
   @Test
   void testBasicScheduling() {
     val runs =
         List.of(
-            createRun("run-1", RunState.RUNNING, ALIGN_WF_URL, WORK_DIR_0),
-            createRun("run-2", RunState.QUEUED, ALIGN_WF_URL, WORK_DIR_TEMPLATE));
+            createRun(
+                "run-1",
+                RunState.RUNNING,
+                ALIGN_WF_URL,
+                getDirectory(WORK_DIR_0),
+                getCluster(WORK_DIR_0)),
+            createRun("run-2", RunState.QUEUED, ALIGN_WF_URL, WORK_DIR_TEMPLATE, null));
     val initializedRuns = dirScheduler.getNextInitializedRuns(ImmutableList.copyOf(runs));
 
-    val expectedRuns = List.of(createRun("run-2", RunState.INITIALIZING, ALIGN_WF_URL, WORK_DIR_1));
+    // val expectedRuns = List.of(createRun("run-2", RunState.INITIALIZING, ALIGN_WF_URL,
+    // WORK_DIR_1));
+    val expectedRuns =
+        List.of(
+            createRun(
+                "run-2",
+                RunState.INITIALIZING,
+                ALIGN_WF_URL,
+                getDirectory(WORK_DIR_1),
+                getCluster(WORK_DIR_1)));
 
     assertIterableEquals(expectedRuns, initializedRuns);
   }
@@ -56,17 +97,27 @@ public class DirSchedulerTests {
     // currently running leaves no available dirs
     val allRuns =
         ImmutableList.of(
-            createRun("run-1", RunState.RUNNING, ALIGN_WF_URL, WORK_DIR_0),
-            createRun("run-2", RunState.RUNNING, ALIGN_WF_URL, WORK_DIR_1),
-            createRun("run-3", RunState.QUEUED, HELLO_WF_URL, "emptyDir"),
-            createRun("run-4", RunState.QUEUED, HELLO_WF_URL, null));
+            createRun(
+                "run-1",
+                RunState.RUNNING,
+                ALIGN_WF_URL,
+                getDirectory(WORK_DIR_0),
+                getCluster(WORK_DIR_0)),
+            createRun(
+                "run-2",
+                RunState.RUNNING,
+                ALIGN_WF_URL,
+                getDirectory(WORK_DIR_1),
+                getCluster(WORK_DIR_1)),
+            createRun("run-3", RunState.QUEUED, HELLO_WF_URL, "emptyDir", null),
+            createRun("run-4", RunState.QUEUED, HELLO_WF_URL, null, null));
     val initializedRuns = dirScheduler.getNextInitializedRuns(allRuns);
 
     // runs that don't need dirs are still initialized
     val expectedInitializedRuns =
         List.of(
-            createRun("run-3", RunState.INITIALIZING, HELLO_WF_URL, "emptyDir"),
-            createRun("run-4", RunState.INITIALIZING, HELLO_WF_URL, null));
+            createRun("run-3", RunState.INITIALIZING, HELLO_WF_URL, "emptyDir", null),
+            createRun("run-4", RunState.INITIALIZING, HELLO_WF_URL, null, null));
 
     assertThat(initializedRuns).hasSameElementsAs(expectedInitializedRuns);
   }
@@ -76,20 +127,40 @@ public class DirSchedulerTests {
     // we have one workflow which takes cost of 1 running in a dir which has max cost of 2
     val allRuns =
         ImmutableList.of(
-            createRun("run-1", RunState.RUNNING, WGS_SANGER_WF_URL, WORK_DIR_0),
-            createRun("run-2", RunState.QUEUED, WGS_SANGER_WF_URL, WORK_DIR_TEMPLATE),
-            createRun("run-3", RunState.QUEUED, WGS_SANGER_WF_URL, WORK_DIR_TEMPLATE),
-            createRun("run-4", RunState.QUEUED, WGS_SANGER_WF_URL, WORK_DIR_TEMPLATE),
-            createRun("run-5", RunState.QUEUED, WGS_SANGER_WF_URL, WORK_DIR_TEMPLATE));
+            createRun(
+                "run-1",
+                RunState.RUNNING,
+                WGS_SANGER_WF_URL,
+                getDirectory(WORK_DIR_0),
+                getCluster(WORK_DIR_0)),
+            createRun("run-2", RunState.QUEUED, WGS_SANGER_WF_URL, WORK_DIR_TEMPLATE, null),
+            createRun("run-3", RunState.QUEUED, WGS_SANGER_WF_URL, WORK_DIR_TEMPLATE, null),
+            createRun("run-4", RunState.QUEUED, WGS_SANGER_WF_URL, WORK_DIR_TEMPLATE, null),
+            createRun("run-5", RunState.QUEUED, WGS_SANGER_WF_URL, WORK_DIR_TEMPLATE, null));
     val initializedRuns = dirScheduler.getNextInitializedRuns(allRuns);
 
     // expect 4 to be init since queued are cost 1 and we have 1 cost in the first dir plus 2 in the
     // next
     val expectedInitializedRuns =
         List.of(
-            createRun("run-3", RunState.INITIALIZING, WGS_SANGER_WF_URL, WORK_DIR_0),
-            createRun("run-4", RunState.INITIALIZING, WGS_SANGER_WF_URL, WORK_DIR_1),
-            createRun("run-5", RunState.INITIALIZING, WGS_SANGER_WF_URL, WORK_DIR_1));
+            createRun(
+                "run-3",
+                RunState.INITIALIZING,
+                WGS_SANGER_WF_URL,
+                getDirectory(WORK_DIR_1),
+                getCluster(WORK_DIR_1)),
+            createRun(
+                "run-4",
+                RunState.INITIALIZING,
+                WGS_SANGER_WF_URL,
+                getDirectory(WORK_DIR_1),
+                getCluster(WORK_DIR_1)),
+            createRun(
+                "run-5",
+                RunState.INITIALIZING,
+                WGS_SANGER_WF_URL,
+                getDirectory(WORK_DIR_0),
+                getCluster(WORK_DIR_0)));
 
     assertThat(initializedRuns).hasSameElementsAs(expectedInitializedRuns);
   }
@@ -98,19 +169,34 @@ public class DirSchedulerTests {
   void testSchedulingMultipleTypesOfWorkflow() {
     val allRuns =
         ImmutableList.of(
-            createRun("run-1", RunState.RUNNING, WGS_SANGER_WF_URL, WORK_DIR_0),
-            createRun("run-2", RunState.QUEUED, ALIGN_WF_URL, WORK_DIR_TEMPLATE),
-            createRun("run-3", RunState.QUEUED, WGS_SANGER_WF_URL, WORK_DIR_TEMPLATE),
-            createRun("run-4", RunState.QUEUED, WGS_SANGER_WF_URL, WORK_DIR_TEMPLATE),
-            createRun("run-5", RunState.QUEUED, ALIGN_WF_URL, WORK_DIR_TEMPLATE));
+            createRun(
+                "run-1",
+                RunState.RUNNING,
+                WGS_SANGER_WF_URL,
+                getDirectory(WORK_DIR_0),
+                getCluster(WORK_DIR_0)),
+            createRun("run-2", RunState.QUEUED, ALIGN_WF_URL, WORK_DIR_TEMPLATE, null),
+            createRun("run-3", RunState.QUEUED, WGS_SANGER_WF_URL, WORK_DIR_TEMPLATE, null),
+            createRun("run-4", RunState.QUEUED, WGS_SANGER_WF_URL, WORK_DIR_TEMPLATE, null),
+            createRun("run-5", RunState.QUEUED, ALIGN_WF_URL, WORK_DIR_TEMPLATE, null));
 
     val initializedRuns = dirScheduler.getNextInitializedRuns(allRuns);
 
     // there is enough room to schedule an align in work_dir_1 and one more sanger in work_dir_0
     val expectedInitializedRuns =
         List.of(
-            createRun("run-5", RunState.INITIALIZING, ALIGN_WF_URL, WORK_DIR_1),
-            createRun("run-4", RunState.INITIALIZING, WGS_SANGER_WF_URL, WORK_DIR_0));
+            createRun(
+                "run-5",
+                RunState.INITIALIZING,
+                ALIGN_WF_URL,
+                getDirectory(WORK_DIR_1),
+                getCluster(WORK_DIR_1)),
+            createRun(
+                "run-4",
+                RunState.INITIALIZING,
+                WGS_SANGER_WF_URL,
+                getDirectory(WORK_DIR_0),
+                getCluster(WORK_DIR_0)));
 
     assertThat(initializedRuns).hasSameElementsAs(expectedInitializedRuns);
   }
@@ -120,34 +206,60 @@ public class DirSchedulerTests {
     val allRuns =
         ImmutableList.of(
             createRun(
-                "run-unknown", RunState.RUNNING, "https://github.com/unknown/repo.git", WORK_DIR_1),
-            createRun("run-other-sanger", RunState.RUNNING, WGS_SANGER_WF_URL, "/test"),
-            createRun("run-1", RunState.QUEUED, WGS_SANGER_WF_URL, WORK_DIR_TEMPLATE),
-            createRun("run-2", RunState.QUEUED, WGS_SANGER_WF_URL, WORK_DIR_TEMPLATE),
-            createRun("run-3", RunState.QUEUED, WGS_SANGER_WF_URL, WORK_DIR_TEMPLATE),
-            createRun("run-4", RunState.QUEUED, WGS_SANGER_WF_URL, WORK_DIR_TEMPLATE));
+                "run-unknown",
+                RunState.RUNNING,
+                "https://github.com/unknown/repo.git",
+                getDirectory(WORK_DIR_1),
+                getCluster(WORK_DIR_1)),
+            createRun("run-other-sanger", RunState.RUNNING, WGS_SANGER_WF_URL, "/test", null),
+            createRun("run-1", RunState.QUEUED, WGS_SANGER_WF_URL, WORK_DIR_TEMPLATE, null),
+            createRun("run-2", RunState.QUEUED, WGS_SANGER_WF_URL, WORK_DIR_TEMPLATE, null),
+            createRun("run-3", RunState.QUEUED, WGS_SANGER_WF_URL, WORK_DIR_TEMPLATE, null),
+            createRun("run-4", RunState.QUEUED, WGS_SANGER_WF_URL, WORK_DIR_TEMPLATE, null),
+            createRun("run-5", RunState.QUEUED, WGS_SANGER_WF_URL, WORK_DIR_TEMPLATE, null));
 
     val initializedRuns = dirScheduler.getNextInitializedRuns(allRuns);
 
-    // `run-other-sanger` is a wgs_sanger and these workflows are config with max limit of 4
-    // which means only 3 new runs should be init.
+    // `run-other-sanger` is a wgs_sanger and these workflows are config with max limit of 5
+    // which means only 4 new runs should be init.
     // `run-other-unknown` is using WORK_DIR_1 but its not configured so no cost can be associated
     // which is why its is ignored in scheduling
     val expectedInitializedRuns =
         List.of(
-            createRun("run-2", RunState.INITIALIZING, WGS_SANGER_WF_URL, WORK_DIR_0),
-            createRun("run-3", RunState.INITIALIZING, WGS_SANGER_WF_URL, WORK_DIR_1),
-            createRun("run-4", RunState.INITIALIZING, WGS_SANGER_WF_URL, WORK_DIR_1));
+            createRun(
+                "run-2",
+                RunState.INITIALIZING,
+                WGS_SANGER_WF_URL,
+                getDirectory(WORK_DIR_1),
+                getCluster(WORK_DIR_1)),
+            createRun(
+                "run-3",
+                RunState.INITIALIZING,
+                WGS_SANGER_WF_URL,
+                getDirectory(WORK_DIR_1),
+                getCluster(WORK_DIR_1)),
+            createRun(
+                "run-4",
+                RunState.INITIALIZING,
+                WGS_SANGER_WF_URL,
+                getDirectory(WORK_DIR_0),
+                getCluster(WORK_DIR_0)),
+            createRun(
+                "run-5",
+                RunState.INITIALIZING,
+                WGS_SANGER_WF_URL,
+                getDirectory(WORK_DIR_0),
+                getCluster(WORK_DIR_0)));
 
     assertThat(initializedRuns).hasSameElementsAs(expectedInitializedRuns);
   }
 
-  Run createRun(String runId, RunState runState, String url, String baseDir) {
+  Run createRun(String runId, RunState runState, String url, String baseDir, String cluster) {
     return Run.builder()
         .runId(runId)
         .state(runState)
         .workflowUrl(url)
-        .workflowParamsJsonStr("{\"baseDir\": \"" + baseDir + "\"}")
+        .workflowParamsJsonStr(createWorkflowParamJson(baseDir, cluster))
         .workflowEngineParams(
             Run.EngineParams.builder()
                 .projectDir(baseDir + "/project/dir/path")
@@ -155,5 +267,20 @@ public class DirSchedulerTests {
                 .workDir(baseDir + "/work/dir/path")
                 .build())
         .build();
+  }
+
+  private String createWorkflowParamJson(String baseDir, String cluster) {
+    if (StringUtils.isBlank(cluster)) {
+      return "{\"baseDir\": \"" + baseDir + "\"}";
+    }
+    return "{\"baseDir\": \"" + baseDir + "\"," + "\"cluster\":\"" + cluster + "\"}";
+  }
+
+  private String getDirectory(String workDir) {
+    return workDir.split(":")[0];
+  }
+
+  private String getCluster(String workDir) {
+    return workDir.split(":")[1];
   }
 }


### PR DESCRIPTION
Reference ticket: [#33](https://github.com/icgc-argo/workflow-management-scheduler/issues/33)

The scheduler will allocate work directories in the external cluster to the incoming workflow jobs and also inform management about the cluster in which to fire the jobs. Work directory allocation is still based on the cost calculation performed by the Scheduler